### PR TITLE
fix(scripts): keep generated audit JSON output parseable

### DIFF
--- a/.github/scripts/generated-audit-wrappers.test.cjs
+++ b/.github/scripts/generated-audit-wrappers.test.cjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+// Opt-in integration: generate the real child theme and install a packed Core
+// artifact. No network installation is added to the ordinary contract tests.
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const { createHash } = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '../..');
+const excluded = new Set(['.git', 'node_modules', 'dist', '.out', '.coverage', '.cache']);
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function run(command, args, cwd, env) {
+  const result = spawnSync(command, args, {
+    cwd,
+    env,
+    encoding: 'utf8',
+    timeout: 180000,
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  assert.ifError(result.error);
+  assert.equal(result.signal, null, `Unexpected signal: ${result.signal}`);
+  return result;
+}
+
+function assertWrapper(result, direct, footer) {
+  assert.equal(result.status, direct.status, 'Wrapper must preserve the exact Core exit status.');
+  let report;
+  assert.doesNotThrow(() => {
+    // Parsing a substring or dropping a footer would conceal this regression.
+    report = JSON.parse(result.stdout);
+  }, 'The entire stdout stream must be valid JSON.');
+  assert.deepEqual(report, JSON.parse(direct.stdout), 'Wrapper must forward every argument unchanged.');
+  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.tool.name, '@emulsify/core');
+  assert.equal(result.stderr, `${direct.stderr}\n${footer}\n`, 'The exact documentation footer belongs on stderr.');
+  assert.ok(!result.stdout.includes(footer), 'Documentation footer must not enter stdout.');
+}
+
+test('real generated audit wrappers retain the packed Core CLI contract', { timeout: 240000 }, async (t) => {
+  assert.ok(process.env.EMULSIFY_CORE_TARBALL, 'Set EMULSIFY_CORE_TARBALL to a local npm pack .tgz artifact.');
+  const tarball = path.resolve(process.env.EMULSIFY_CORE_TARBALL);
+  const tarballHash = createHash('sha256').update(fs.readFileSync(tarball)).digest('hex');
+  const workRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'emulsify-generated-audit-'));
+  const consumer = path.join(workRoot, 'generated child with spaces');
+  const env = {
+    ...process.env,
+    CI: '1',
+    FORCE_COLOR: '0',
+    PUPPETEER_SKIP_DOWNLOAD: 'true',
+    npm_config_cache: process.env.npm_config_cache || path.join(workRoot, 'npm-cache'),
+  };
+
+  try {
+    fs.cpSync(path.join(repoRoot, 'whisk'), consumer, {
+      recursive: true,
+      filter: (source) => !excluded.has(path.basename(source)),
+    });
+    const projectPath = path.join(consumer, 'project.emulsify.json');
+    const project = JSON.parse(fs.readFileSync(projectPath, 'utf8'));
+    Object.assign(project.project, {
+      name: 'Audit Fixture', machineName: 'audit-fixture', description: 'Generated audit wrapper contract.',
+    });
+    writeJson(projectPath, project);
+    const generation = run(process.execPath, [path.join(consumer, '.cli/init.js')], consumer, env);
+    assert.equal(generation.status, 0, generation.stderr);
+    const packagePath = path.join(consumer, 'package.json');
+    const generated = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+    const source = JSON.parse(fs.readFileSync(path.join(repoRoot, 'whisk/package.json'), 'utf8'));
+    assert.deepEqual(generated.scripts, source.scripts, 'Generation must retain the real starter scripts.');
+    const install = run(npm, ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--package-lock=false', '--save-exact', tarball], consumer, env);
+    assert.equal(install.status, 0, install.stderr);
+    const installed = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+    assert.deepEqual(installed.scripts, generated.scripts);
+    const coreRoot = path.join(consumer, 'node_modules/@emulsify/core');
+    assert.equal(fs.lstatSync(coreRoot).isSymbolicLink(), false, 'Use an installed package, not a source symlink.');
+    const coreVersion = JSON.parse(fs.readFileSync(path.join(coreRoot, 'package.json'), 'utf8')).version;
+    t.diagnostic(JSON.stringify({ coreVersion, tarballSha256: tarballHash, generatedScripts: { audit: generated.scripts.audit, 'audit:twig-stories': generated.scripts['audit:twig-stories'] } }));
+
+    const auditRoot = path.join(workRoot, 'audit root with spaces');
+    const component = path.join(auditRoot, 'src/components/card');
+    fs.mkdirSync(component, { recursive: true });
+    writeJson(path.join(auditRoot, 'project.emulsify.json'), { project: { platform: 'none' } });
+    fs.writeFileSync(path.join(component, 'card.twig'), '<p>{{ title }}</p>');
+    fs.writeFileSync(path.join(component, 'card.stories.js'), 'import cardTwig from "./card.twig";\nexport const Card = (args) => cardTwig(args);\n');
+    const cleanRoot = path.join(workRoot, 'clean root with spaces');
+    const cleanComponent = path.join(cleanRoot, 'src/components/clean');
+    fs.mkdirSync(cleanComponent, { recursive: true });
+    writeJson(path.join(cleanRoot, 'project.emulsify.json'), { project: { platform: 'none' } });
+    fs.writeFileSync(path.join(cleanComponent, 'clean.stories.js'), 'export default { title: "Audit/Clean" };\nexport const Clean = () => "<p>Clean</p>";\n');
+
+    for (const [script, executable, footer, threshold] of [
+      ['audit', 'audit.js', 'Audit docs: https://github.com/emulsify-ds/emulsify-core/blob/4.x/docs/migration-4x.md#storybook-migration', ['--fail-on', 'warn']],
+      ['audit:twig-stories', 'audit-twig-stories.js', 'Migration docs: https://github.com/emulsify-ds/emulsify-core/blob/4.x/docs/storybook.md#legacy-twig-story-compatibility', ['--fail-on-found']],
+    ]) {
+      const args = ['--root', auditRoot, '--json'];
+      const directRun = (options) => run(path.join(coreRoot, 'scripts', executable), options, consumer, env);
+      const wrapperRun = (options) => run(npm, ['run', script, '--silent', '--', ...options], consumer, env);
+      for (const [scenario, options, expectedStatus] of [
+        ['clean scan', ['--root', cleanRoot, '--json', ...threshold], 0],
+        ['advisory findings', args, 0],
+        ['findings fail threshold', [...args, ...threshold], 1],
+        ['invalid argument', [...args, '--unknown-wrapper-option'], 2],
+      ]) {
+        await t.test(`${script}: ${scenario}`, () => {
+          const direct = directRun(options);
+          assert.equal(direct.status, expectedStatus, direct.stderr);
+          const report = JSON.parse(direct.stdout);
+          if (scenario === 'clean scan') {
+            assert.deepEqual(report.findings, []);
+          } else if (expectedStatus !== 2) {
+            assert.ok(report.findings.some((finding) => finding.id === 'legacy-twig-story' && finding.path === 'src/components/card/card.stories.js' && finding.line === 2 && finding.severity === 'warn'));
+          }
+          const wrapped = wrapperRun(options);
+          assertWrapper(wrapped, direct, footer);
+          const executableName = executable === 'audit.js' ? 'emulsify-audit' : 'emulsify-audit-twig-stories';
+          const directAlias = run(npx, ['--no-install', executableName, ...options], consumer, env);
+          assert.equal(directAlias.status, expectedStatus);
+          assert.deepEqual(JSON.parse(directAlias.stdout), report);
+          assert.equal(directAlias.stderr, direct.stderr);
+          t.diagnostic(JSON.stringify({ script, scenario, options, directStatus: direct.status, wrapperStatus: wrapped.status, npxNoInstallStatus: directAlias.status, wholeStdoutJson: true, footerOnStderr: true }));
+        });
+      }
+
+      for (const [scenario, mutate, expectedFailure] of [
+        ['rejects stdout footer', (command) => command.replace(' >&2;', ';'), /entire stdout stream/],
+        ['rejects masked status', (command) => command.replace('exit $status', 'exit 0'), /exact Core exit status/],
+        ['rejects dropped arguments', (command) => command.replace('"$@"', ''), /exact Core exit status|forward every argument/],
+      ]) {
+        await t.test(`${script}: ${scenario}`, () => {
+          const modified = structuredClone(installed);
+          modified.scripts[script] = mutate(modified.scripts[script]);
+          assert.notEqual(modified.scripts[script], installed.scripts[script]);
+          writeJson(packagePath, modified);
+          try {
+            const options = [...args, ...threshold];
+            assert.throws(() => assertWrapper(wrapperRun(options), directRun(options), footer), expectedFailure);
+          } finally {
+            writeJson(packagePath, installed);
+          }
+        });
+      }
+    }
+  } finally {
+    fs.rmSync(workRoot, { recursive: true, force: true });
+  }
+});

--- a/docs/generated-child-theme-contract.md
+++ b/docs/generated-child-theme-contract.md
@@ -52,6 +52,20 @@ npm run release:check -- --skip-smoke
 
 `npm run test:generated-theme` runs focused contract tests that generate a throwaway theme and then mutate it to prove each class of failure is detected. `npm run smoke:generation-parity` generates through both paths and compares them; it requires a PHP binary and skips with a warning when none is available.
 
+To verify generated audit wrappers against an actual packed Core artifact, run:
+
+```sh
+EMULSIFY_CORE_TARBALL=/absolute/path/emulsify-core-4.5.0.tgz npm run test:audit-wrappers
+```
+
+This opt-in test generates a temporary child theme and installs that package
+without installer hooks. It compares both wrappers with the installed Core
+executables, checks complete JSON stdout, stderr footers, exit codes 0/1/2, and
+arguments containing spaces. Negative controls prove that stdout footers,
+masked failures, and dropped arguments are detected. It requires Node 24 and
+registry access for the packed package's dependencies; it leaves the source
+theme and dependency ranges unchanged.
+
 The full release check additionally exercises a real WordPress fixture:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "pr:check": "node .github/scripts/pr-validation.cjs",
     "release:check": "node .github/scripts/release-check.cjs",
     "test:generated-theme": "node --test .github/scripts/generated-theme-contract.test.cjs",
+    "test:audit-wrappers": "node --test .github/scripts/generated-audit-wrappers.test.cjs",
     "smoke:acf-json": "php .github/scripts/acf-local-json-smoke.php",
     "smoke:asset-manifest": "php .github/scripts/asset-manifest-smoke.php",
     "smoke:attributes": "php .github/scripts/attribute-helper-smoke.php",

--- a/whisk/docs/development.md
+++ b/whisk/docs/development.md
@@ -91,6 +91,39 @@ npm run a11y
 
 `npm run test` succeeds when no tests have been added yet. The accessibility check builds Storybook first, so it takes longer than lint or unit tests.
 
+For machine-readable project audits, silence npm's command banner and keep the
+documentation footer on stderr:
+
+```bash
+npm run audit --silent -- --json
+npm run audit:twig-stories --silent -- --json
+```
+
+Both wrappers preserve Core's exit status and forward arguments unchanged. Use
+`npm run audit --silent -- --json --fail-on warn` or
+`npm run audit:twig-stories --silent -- --json --fail-on-found` to fail when
+migration findings are present. Quote paths containing spaces, for example
+`npm run audit --silent -- --root "../theme source" --json`. Existing generated
+themes must copy the updated audit scripts from the current starter; updating
+Core alone does not change a project's `package.json`.
+
+To update an existing wrapper, keep `"$@"`, the `status=$?` immediately after
+Core runs, and `exit $status`. Add only `>&2` after the footer's `printf`:
+
+```diff
+- printf "\nAudit docs: https://github.com/emulsify-ds/emulsify-core/blob/4.x/docs/migration-4x.md#storybook-migration\n"; exit $status
++ printf "\nAudit docs: https://github.com/emulsify-ds/emulsify-core/blob/4.x/docs/migration-4x.md#storybook-migration\n" >&2; exit $status
+```
+
+Apply the same redirection to `audit:twig-stories`, retaining its existing
+`Migration docs:` footer. Alternatively, bypass the project wrappers and run
+the installed Core executables directly without downloading another version:
+
+```bash
+npx --no-install emulsify-audit --json
+npx --no-install emulsify-audit-twig-stories --json
+```
+
 ## Project ownership
 
 ### Component library

--- a/whisk/package.json
+++ b/whisk/package.json
@@ -18,8 +18,8 @@
   "type": "module",
   "scripts": {
     "a11y": "npm run storybook-build && node config/emulsify-core/run-a11y.js",
-    "audit": "sh -c 'node_modules/@emulsify/core/scripts/audit.js \"$@\"; status=$?; printf \"\\nAudit docs: https://github.com/emulsify-ds/emulsify-core/blob/4.x/docs/migration-4x.md#storybook-migration\\n\"; exit $status' --",
-    "audit:twig-stories": "sh -c 'node_modules/@emulsify/core/scripts/audit-twig-stories.js \"$@\"; status=$?; printf \"\\nMigration docs: https://github.com/emulsify-ds/emulsify-core/blob/4.x/docs/storybook.md#legacy-twig-story-compatibility\\n\"; exit $status' --",
+    "audit": "sh -c 'node_modules/@emulsify/core/scripts/audit.js \"$@\"; status=$?; printf \"\\nAudit docs: https://github.com/emulsify-ds/emulsify-core/blob/4.x/docs/migration-4x.md#storybook-migration\\n\" >&2; exit $status' --",
+    "audit:twig-stories": "sh -c 'node_modules/@emulsify/core/scripts/audit-twig-stories.js \"$@\"; status=$?; printf \"\\nMigration docs: https://github.com/emulsify-ds/emulsify-core/blob/4.x/docs/storybook.md#legacy-twig-story-compatibility\\n\" >&2; exit $status' --",
     "build": "npm run ensure-dist && vite build --config node_modules/@emulsify/core/config/vite/vite.config.js",
     "coverage": "npm run test && open-cli .coverage/lcov-report/index.html",
     "develop": "npm run ensure-dist && concurrently --raw --no-shell npm:vite npm:storybook",


### PR DESCRIPTION
**This PR does the following:**

- Keeps the documentation footer from contaminating the JSON emitted by generated child themes' `audit` and `audit:twig-stories` scripts. The footer goes to stderr; Core's arguments and exit status are preserved.
- Adds an opt-in regression that generates an actual child theme, installs a local packed Core artifact, and compares both npm wrappers with the installed executables. Covers clean and advisory exit 0, findings exit 1, invalid-argument exit 2, paths containing spaces, whole stdout JSON, exact stderr footers, and live negative controls for stdout footers, masked failures, and dropped arguments.
- Documents silent npm invocations, the exact `>&2` migration, and both verified `npx --no-install` alternatives for existing generated themes.

### Related Issue(s)

- [Core 4.5.0 release preparation](https://github.com/emulsify-ds/emulsify-core/pull/314)

### Notes:

The published WordPress 2.0.0 starter has the stdout footer. Existing generated themes need to copy the corrected scripts; upgrading `@emulsify/core` alone does not rewrite their `package.json`. Dependency ranges, versions, and release workflows are unchanged.

The integration test requires Node 24, a local `npm pack` artifact, and registry access for its dependencies. It uses temporary generated output, disables installer hooks, and does not require a browser. Verification used Core 4.5.0 from commit `9474984fe9ea3b36c03240e32d3e18961e838bfe`, tarball SHA-256 `6b6d322b43d4f0545eee4584e1015d84f20b347c3317428e69952c13fddc38f5`.

### Functional Testing:

- [x] `EMULSIFY_CORE_TARBALL=/absolute/path/emulsify-core-4.5.0.tgz npm run test:audit-wrappers` — 15 tests passed; the original wrappers failed complete-stdout JSON parsing for both commands and all three Core exit statuses.
- [x] `npm run test:generated-theme` — 12 tests passed.
- [x] `EMULSIFY_PARITY_REQUIRED=1 npm run smoke:generation-parity` — both generation paths matched across 34 files for each of two identities.
- [x] `npm run docs:check-commands` — 11 documentation sections passed.
- [x] `npm run lint` — PHPCS and PHPStan passed.
- [ ] Confirm `Practical theme readiness`, `PHP coding standards and static analysis`, `WordPress fixture smoke`, and `Extended Whisk Storybook and a11y` pass for changes targeting the protected release branches.
